### PR TITLE
Add additional 500 errors to already_sent_error?

### DIFF
--- a/models/request_result.rb
+++ b/models/request_result.rb
@@ -41,8 +41,9 @@ class RequestResult
   end
 
   def self.already_sent_error?(message_hash)
+    error_list = ["Your request has already been sent", "already on hold for or checked out to you"]
     hash = JSON.parse(message_hash["message"])
-    (hash.is_a? Hash) && (hash["description"].is_a? String) && (hash["description"].include?("Your request has already been sent"))
+    (hash.is_a? Hash) && (hash["description"].is_a? String) && error_list.any? {|error| hash["description"].include?(error)}
   end
 
   def self.patron_already_has_hold?(hold_request)


### PR DESCRIPTION
This branch updates the way we check to see if an error needs to be passed to SCSB. It adds a list of error messages that can be ignored, where before we were only looking for one error message