### PR TITLE
Change Makefile: standardize aws profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ package: ## Package the code for AWS Lambda
 
 create_development: ## Creates an AWS lambda function
 	@cp config/var_dev.env config/var_deploy.env
-	@export AWS_DEFAULT_PROFILE=development
 	aws lambda create-function \
 		--function-name RecapHoldRequestConsumer-development \
 		--handler index.handler \
@@ -49,20 +48,18 @@ create_development: ## Creates an AWS lambda function
 		--description "Processes hold requests from recap" \
 		--role arn:aws:iam::224280085904:role/lambda_basic_execution \
 		--zip-file fileb://./deploy/rhrc.zip \
-		--profile development
+		--profile nypl-sandbox
 
 deploy_development:  ## Deploys the latest version to AWS development
 	@cp config/var_dev.env config/var_deploy.env
-	@export AWS_DEFAULT_PROFILE=development
 	@make package
 	aws lambda update-function-code \
 		--function-name RecapHoldRequestConsumer-development \
 		--zip-file fileb://./deploy/rhrc.zip \
-		--profile development
+		--profile nypl-sandbox
 
 create_qa:
 	@cp config/var_qa.env config/var_deploy.env
-	@export AWS_DEFAULT_PROFILE=qa
 	aws lambda create-function \
 		--function-name RecapHoldRequestConsumer-qa \
 		--handler index.handler \
@@ -72,16 +69,15 @@ create_qa:
 		--description "Processes hold requests from recap" \
 		--role arn:aws:iam::946183545209:role/lambda-full-access \
 		--zip-file fileb://./deploy/rhrc.zip \
-		--profile qa
+		--profile nypl-digital-dev
 
 deploy_qa: ## Deploys the latest version to AWS QA
 	@cp config/var_qa.env config/var_deploy.env
-	@export AWS_DEFAULT_PROFILE=qa
 	@make package
 	aws lambda update-function-code \
 		--function-name RecapHoldRequestConsumer-qa \
 		--zip-file fileb://./deploy/rhrc.zip \
-		--profile qa
+		--profile nypl-digital-dev
 
 deploy_production: ## Deploys the latest version to AWS development
 	@cp config/var_prod.env config/var_deploy.env

--- a/README.md
+++ b/README.md
@@ -158,3 +158,14 @@ For NCIP:
   * description (should have a title, author, and call number)
   In HOLD_REQUEST_DATA:
   * deliveryLocation
+
+### Testing after deployment
+
+To test real data in the hold request pipeline you'll want to generate an actual hold request using the SCSB UI - ideally modelling the following scenarios:
+
+1. NYPL patron hold request for an NYPL item
+2. NYPL patron hold request for a partner item
+
+Note that testing partner hold requests for NYPL items is a special case of 1. above. The final possible scenario - a partner hold request for a partner item - doesn't touch our systems.
+
+For more info on what's happening, review the [NYPL Patron Hold Request Architecture diagram](https://docs.google.com/presentation/d/1Tmb53yOUett1TLclwkUWa-14EOG9dujAyMdLzXOdOVc/edit#slide=id.g330b256cdf_0_0) and related [workflow documentation](https://github.com/NYPL/lsp_workflows/blob/master/workflows/patron_hold_request.md).


### PR DESCRIPTION
Changes `Makefile` to use standard AWS profile names ("nypl-digital-dev" and "nypl-sandbox")

Also adds notes on integration testing post deployment.