### PR TITLE
SCC 2642: Remove 8 locations from "suppressed" to allow holds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ deploy:
   access_key_id: "$AWS_ACCESS_KEY_ID_PRODUCTION"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_PRODUCTION"
   on:
-    branch: master
+    branch: main
 notifications:
   email:
     on_failure: always

--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ For NCIP:
   * description (should have a title, author, and call number)
   In HOLD_REQUEST_DATA:
   * deliveryLocation
+
+## Contributing
+
+This repo uses the [Development-QA-Main Git Workflow](https://github.com/NYPL/engineering-general/blob/master/standards/git-workflow.md#development-qa-main)

--- a/models/sierra_request.rb
+++ b/models/sierra_request.rb
@@ -14,7 +14,7 @@ class SierraRequest
   # These codes will trigger an automatically successful response being sent to the HoldRequestResult stream.
   # Technically speaking, they are codes that prevent holds. But we're treating any requests that come through with them as successful.
   # TODO: Can we make this data driven using nypl-core?
-  SUPPRESSION_CODES = ['BD', 'GO', 'IN', 'NC', 'NE', 'NI', 'NK', 'NO', 'NR', 'NS', 'NT', 'NU', 'NV', 'NX', 'NY', 'NZ', 'OB', 'OM', 'OP', 'OS', 'OZ', 'QP', 'RR', 'SA', 'SM', 'SP', 'OI']
+  SUPPRESSION_CODES = ['BD', 'GO', 'IN', 'NC', 'NE', 'NI', 'NK', 'NT', 'NU', 'NX', 'NY', 'OB', 'OM', 'OP', 'OS', 'OZ', 'QP', 'RR', 'OI']
 
   def initialize(json_data)
     self.json_body = json_data


### PR DESCRIPTION
Based on conversation with Research staff, this removes 8 recap customer
codes from the array of "suppressed" locations so that the app creates a
hold on those items. A recap customer code's presence in the
SUPPRESSION_CODES array causes this app to *skip* placing a hold on any
item destined for those locations.

Also since some tests depended on NV being suppressed (which we're changing),
this swaps NV for NC (which remains suppressed) in tests about
suppressed locations.

Also adds Git Workflow to README and renames `master` to `main`

https://jira.nypl.org/browse/SCC-2642