### PR TITLE
Add prefix for OTF records from Harvard HD

### DIFF
--- a/models/sierra_request.rb
+++ b/models/sierra_request.rb
@@ -121,11 +121,17 @@ class SierraRequest
 
     hold_data = hold_request["data"]
 
+    # If title indicates item is in Harvard HD, add [HD] prefix:
+    title = recap_hold_request["description"]["title"] || ''
+    if recap_hold_request['owningInstitutionId'] == 'HL' && title.match(/\[HD\]$/)
+      title = "[HD] #{title}"
+    end
+
     virtual_record = SierraVirtualRecord.create({
       item_barcode: recap_hold_request["itemBarcode"],
       call_number: recap_hold_request["description"]["callNumber"],
       author: recap_hold_request["description"]["author"],
-      title: recap_hold_request["description"]["title"]
+      title: title
     })
 
     # Now that we've localized the partner item as an NYPL item, we can process

--- a/spec/fixtures/recap-hold-request-hl-hd.json
+++ b/spec/fixtures/recap-hold-request-hl-hd.json
@@ -1,0 +1,14 @@
+{
+  "id": 1605,
+  "trackingId": "hold-request-id-1234",
+  "patronBarcode": "23333090799527",
+  "itemBarcode": "HXTPNA",
+  "createdDate": "2021-06-01T10:09:13-04:00",
+  "updatedDate": null,
+  "owningInstitutionId": "HL",
+  "description": {
+    "title": "[Standard NYPL restrictions apply] \" ... AUF DASS VON DIR DIE NACH-WELT NIMMER SCHWEIGT\" : DIE HERZOGIN ANNA AMALIA BIBLIOTHEK IN WEIMAR NACH DEM BRAND / HERZOGI [HD]",
+    "author": "   ",
+    "callNumber": null
+  }
+}

--- a/spec/fixtures/recap-hold-request-hl.json
+++ b/spec/fixtures/recap-hold-request-hl.json
@@ -1,0 +1,14 @@
+{
+  "id": 1606,
+  "trackingId": "hold-request-id-1234",
+  "patronBarcode": "23333090799527",
+  "itemBarcode": "32044129220349",
+  "createdDate": "2021-06-01T11:04:51-04:00",
+  "updatedDate": null,
+  "owningInstitutionId": "HL",
+  "description": {
+    "title": "[Standard NYPL restrictions apply] \" ... IZ PENZY V MOSKVU I OBRATNO ...\" : SOVREMENNAIA FILOSOFSKAIA PUBLITSISTIKA = \" ... FROM PENZA TO MOSCOW AND BACK ...\" [RECAP]",
+    "author": "Mi͡asnikov, A. G. author. (Andreĭ Gennadʹevich),   ",
+    "callNumber": null
+  }
+}


### PR DESCRIPTION
When processing hold requests for partner items, detects Harvard items
in HD (indicated by [HD] in title) and makes that indicator more
prominent by adding a [HD] prefix.

https://jira.nypl.org/browse/SCC-2727