### PR TITLE
Fix bug handling hold failures at staff locations

### DIFF
--- a/models/kms.rb
+++ b/models/kms.rb
@@ -6,13 +6,16 @@ class Kms
 
   # Decrypts an encoded secret string. Returns nil if error, plaintext key if success. 
   def self.decrypt(encoded_secret)
+    # To work around https://github.com/aws/aws-sam-cli/issues/3118:
+    ENV.delete "AWS_SESSION_TOKEN" if ENV['AWS_SESSION_TOKEN'] == ''
+
     kms = Aws::KMS::Client.new(region: 'us-east-1')
     decoded_string = Base64.decode64(encoded_secret)
     begin
       cleartextkey = kms.decrypt(ciphertext_blob: decoded_string)
       cleartextkey.plaintext
     rescue Exception => e
-      $logger.error "Bad decryption of secret key"
+      $logger.error "Bad decryption of secret key: #{e}"
       nil
     end
   end

--- a/models/sierra_request.rb
+++ b/models/sierra_request.rb
@@ -16,6 +16,12 @@ class SierraRequest
   # TODO: Can we make this data driven using nypl-core?
   SUPPRESSION_CODES = ['BD', 'GO', 'IN', 'NC', 'NE', 'NI', 'NK', 'NT', 'NU', 'NX', 'NY', 'OB', 'OM', 'OP', 'OS', 'OZ', 'QP', 'RR', 'OI']
 
+  # These location codes are also staff-only locations, but
+  #  1) we do attempt to place a hold on items sent to these locations and
+  #  2) if the hold fails, we should ignore it (because it's probably just a
+  #     suppressed item)
+  HOLD_OPTIONAL_STAFF_LOCATIONS = ['NO', 'NR', 'NS', 'NV', 'NZ', 'SA', 'SM', 'SP']
+
   def initialize(json_data)
     self.json_body = json_data
   end

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -24,3 +24,4 @@ Resources:
           RECAP_CLIENT_ID: recap_hold_request_consumer
           HOLD_REQUESTS_URL: https://qa-platform.nypl.org/api/v0.1
           HOLD_REQUEST_RESULT_STREAM: HoldRequestResult-qa
+          LOCATIONS_URL: https://nypl-core-objects-mapping-qa.s3.amazonaws.com/by_recap_customer_code.json

--- a/spec/request_result_spec.rb
+++ b/spec/request_result_spec.rb
@@ -9,6 +9,10 @@ already_sent_hash = {"code"=>"500",
   "message"=>"{\"code\":132,\"specificCode\":2,\"httpStatus\":500,\"name\":\"XCirc error\",\"description\":\"XCirc error : Your request has already been sent.\"}"
 }
 
+suppressed_item_hash = {"code"=>"500",
+  "message"=>"{\"code\":132, \"specificCode\":2, \"httpStatus\":500, \"name\": \"XCirc error\", \"description\": \"XCirc error : This record is not available\"}"
+}
+
 describe RequestResult do
   describe "is_error_type?" do
     before :each do
@@ -29,6 +33,40 @@ describe RequestResult do
 
     it "should identify \"Your request has already been sent.\" as a retryable error" do
       expect(RequestResult.is_error_type?(already_sent_hash, RequestResult.retryable_errors)).to be true
+    end
+
+    it "should identify suppressed item message as an error" do
+      expect(RequestResult.is_error_type?(suppressed_item_hash, RequestResult.possible_item_suppressed_errors)).to be true
+    end
+  end
+
+  describe "process_response" do
+    let(:kinesis_mock) { instance_double(Aws::Kinesis::Client) }
+
+    before do
+      # Route Kinesis writes to a mock
+      mock_kinesis_response = double
+      allow(mock_kinesis_response).to receive(:successful?).and_return(true)
+      allow(kinesis_mock).to receive(:put_record).and_return(mock_kinesis_response)
+      allow(Aws::Kinesis::Client).to receive(:new).and_return(kinesis_mock)
+    end
+
+    it "should handle hold failures at staff-only locations as successes" do
+      json_data = { "trackingId" => "hold-request-id" }
+      hold_request = { "data" => { "jobId" => "job-id", "deliveryLocation" => "NV" } }
+      result = RequestResult.process_response(suppressed_item_hash, 'SierraRequest', json_data, hold_request)
+
+      expect(result).to be_a(Hash)
+      expect(result['code']).to eq('200')
+    end
+
+    it "should handle hold failures at public facing locations as failures" do
+      json_data = { "trackingId" => "hold-request-id" }
+      hold_request = { "data" => { "jobId" => "job-id", "deliveryLocation" => "NH" } }
+      result = RequestResult.process_response(suppressed_item_hash, 'SierraRequest', json_data, hold_request)
+
+      expect(result).to be_a(Hash)
+      expect(result['code']).to eq('500')
     end
   end
 end


### PR DESCRIPTION
Fixes bug where hold failures at staff-only locations result in an error
response, causing the request at SCSB to be rejected. Hold failures at
staff-only locations are almost certainly the result of the item being
suppressed. (And if there's another reason for the failure, we should
allow the item to be retrieved anyway because it's bound for a staff
only location, where staff will know how to handle it.)

https://jira.nypl.org/browse/SCC-2748