### PR TITLE
Add 910 $a 'RLOTF' to OTF bib

### DIFF
--- a/models/sierra_virtual_record.rb
+++ b/models/sierra_virtual_record.rb
@@ -21,6 +21,14 @@ class SierraVirtualRecord
 
     props[:titles] = [@data[:title]] unless (@data[:title] || '').empty?
     props[:authors] = [@data[:author]] unless (@data[:author] || '').empty?
+    # Add a 910 $a with 'RLOTF', identifying this bib as OTF (to keep it out of RC)
+    props[:varFields] = [
+      {
+        :fieldTag => 'y',
+        :marcTag => '910',
+        :subfields => [ { :tag => 'a', :content => 'RLOTF' } ]
+      }
+    ]
 
     $logger.debug "Sierra API POST: bibs #{props.to_json}"
     response = self.class.sierra_client.post 'bibs', props

--- a/spec/sierra_request_spec.rb
+++ b/spec/sierra_request_spec.rb
@@ -260,8 +260,13 @@ describe SierraRequest do
       )
 
       expect(WebMock).to have_requested(:post, "#{ENV['SIERRA_URL']}/bibs").
-        with(body: {"titles":["[Standard NYPL restrictions apply] \" ... IZ PENZY V MOSKVU I OBRATNO ...\" : SOVREMENNAIA FILOSOFSKAIA PUBLITSISTIKA = \" ... FROM PENZA TO MOSCOW AND BACK ...\" [RECAP]"],"authors":["Mi͡asnikov, A. G. author. (Andreĭ Gennadʹevich),   "]},
-          headers: {'Content-Type' => 'application/json'})
+        with(body: {
+            "titles": ["[Standard NYPL restrictions apply] \" ... IZ PENZY V MOSKVU I OBRATNO ...\" : SOVREMENNAIA FILOSOFSKAIA PUBLITSISTIKA = \" ... FROM PENZA TO MOSCOW AND BACK ...\" [RECAP]"],
+            "authors": ["Mi͡asnikov, A. G. author. (Andreĭ Gennadʹevich),   "],
+            "varFields": [{"fieldTag":"y","marcTag":"910","subfields":[{"tag":"a","content":"RLOTF"}]}]
+          },
+          headers: {'Content-Type' => 'application/json'}
+        )
 
       expect(result).to be_a(Hash)
       expect(result['code']).to eq('204')
@@ -273,8 +278,13 @@ describe SierraRequest do
       )
 
       expect(WebMock).to have_requested(:post, "#{ENV['SIERRA_URL']}/bibs").
-        with(body: {"titles":["[HD] [Standard NYPL restrictions apply] \" ... AUF DASS VON DIR DIE NACH-WELT NIMMER SCHWEIGT\" : DIE HERZOGIN ANNA AMALIA BIBLIOTHEK IN WEIMAR NACH DEM BRAND / HERZOGI [HD]"],"authors":["   "]},
-          headers: {'Content-Type' => 'application/json'})
+        with(body: {
+            "titles": ["[HD] [Standard NYPL restrictions apply] \" ... AUF DASS VON DIR DIE NACH-WELT NIMMER SCHWEIGT\" : DIE HERZOGIN ANNA AMALIA BIBLIOTHEK IN WEIMAR NACH DEM BRAND / HERZOGI [HD]"],
+            "authors": ["   "],
+            "varFields": [{"fieldTag":"y","marcTag":"910","subfields":[{"tag":"a","content":"RLOTF"}]}]
+          },
+          headers: {'Content-Type' => 'application/json'}
+        )
 
       expect(result).to be_a(Hash)
       expect(result['code']).to eq('204')


### PR DESCRIPTION
Adds 'RLOTF' to varField 910 $a so that OTF bibs can be clearly
identified (and kept out of RC) whether or not they have items.

This builds on the current practice of tagging Research bibs with
'RL' in the same varfield

https://github.com/NYPL/recap-hold-request-consumer/pull/new/scc-2888