### PR TITLE
Add OL as a suppressed stop code

### DIFF
--- a/models/sierra_request.rb
+++ b/models/sierra_request.rb
@@ -14,7 +14,7 @@ class SierraRequest
   # These codes will trigger an automatically successful response being sent to the HoldRequestResult stream.
   # Technically speaking, they are codes that prevent holds. But we're treating any requests that come through with them as successful.
   # TODO: Can we make this data driven using nypl-core?
-  SUPPRESSION_CODES = ['BD', 'GO', 'IN', 'NC', 'NE', 'NI', 'NK', 'NT', 'NU', 'NX', 'NY', 'OB', 'OM', 'OP', 'OS', 'OZ', 'QP', 'RR', 'OI']
+  SUPPRESSION_CODES = ['BD', 'GO', 'IN', 'NC', 'NE', 'NI', 'NK', 'NT', 'NU', 'NX', 'NY', 'OB', 'OL', 'OM', 'OP', 'OS', 'OZ', 'QP', 'RR', 'OI']
 
   # These location codes are also staff-only locations, but
   #  1) we do attempt to place a hold on items sent to these locations and

--- a/spec/sierra_request_spec.rb
+++ b/spec/sierra_request_spec.rb
@@ -131,7 +131,7 @@ describe SierraRequest do
       expect(sierra_res["code"]).to eq("500") # Given the fake nature of the data, it shouldn't work. But at least it should get to the point of knowing that.
     end
 
-    ['BD', 'NC', 'OI'].each do |location|
+    ['BD', 'NC', 'OI', 'OL'].each do |location|
       it "should automatically return 204 if suppressed deliveryLocation '#{location}'" do
         # Build a fake hold-request instance (so that process_nypl_item doesn't
         # attempt to fetch it itself via [nonexistant] trackingId)::


### PR DESCRIPTION
Adds OL as a "suppressed" stop code to ensure that incoming hold requests that target that delivery location are immediately accepted and a '204' is returned even though we don't attempt to place any hold for the patron (because "suppressed" stop codes represent staff-only no-holds locations).

https://jira.nypl.org/browse/SCC-3345